### PR TITLE
CLOUDP-264640: Add more example commands

### DIFF
--- a/internal/cli/echo/echo.go
+++ b/internal/cli/echo/echo.go
@@ -21,9 +21,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func EchoBuilder() *cobra.Command {
+func Builder() *cobra.Command {
 	return &cobra.Command{
-		Use: "echo",
+		Use:   "echo",
 		Short: "Echos the input args",
 		RunE: func(_ *cobra.Command, args []string) error {
 			if len(args) == 0 {

--- a/internal/cli/hello/hello.go
+++ b/internal/cli/hello/hello.go
@@ -20,11 +20,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func HelloBuilder() *cobra.Command {
+func Builder() *cobra.Command {
 	return &cobra.Command{
-		Use: "hello",
+		Use:   "hello",
 		Short: "The Hello World command",
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, _ []string) {
 			fmt.Println("Hello World!")
 		},
 	}

--- a/internal/cli/printenv/printenv.go
+++ b/internal/cli/printenv/printenv.go
@@ -12,34 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package printenv
 
 import (
 	"fmt"
 	"os"
 
-	"github.com/mongodb/mongodb-atlas-cli/internal/cli/echo"
-	"github.com/mongodb/mongodb-atlas-cli/internal/cli/hello"
-	"github.com/mongodb/mongodb-atlas-cli/internal/cli/printenv"
-	"github.com/mongodb/mongodb-atlas-cli/internal/cli/stdinreader"
 	"github.com/spf13/cobra"
 )
 
-func main() {
-	var rootCmd = &cobra.Command{
-		Use:   "example",
-		Short: "Root command of the atlas cli plugin example",
-	}
-
-	rootCmd.AddCommand(
-		hello.Builder(),
-		echo.Builder(),
-		printenv.Builder(),
-		stdinreader.Builder(),
-	)
-
-	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+func Builder() *cobra.Command {
+	return &cobra.Command{
+		Use:   "printenv",
+		Short: "Prints environment variables",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			fmt.Println("Environment variables: ")
+			for _, env := range os.Environ() {
+				fmt.Printf("\t- %s\n", env)
+			}
+			return nil
+		},
 	}
 }

--- a/internal/cli/stdinreader/stdinreader.go
+++ b/internal/cli/stdinreader/stdinreader.go
@@ -12,34 +12,33 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package stdinreader
 
 import (
+	"bufio"
 	"fmt"
 	"os"
+	"strings"
 
-	"github.com/mongodb/mongodb-atlas-cli/internal/cli/echo"
-	"github.com/mongodb/mongodb-atlas-cli/internal/cli/hello"
-	"github.com/mongodb/mongodb-atlas-cli/internal/cli/printenv"
-	"github.com/mongodb/mongodb-atlas-cli/internal/cli/stdinreader"
 	"github.com/spf13/cobra"
 )
 
-func main() {
-	var rootCmd = &cobra.Command{
-		Use:   "example",
-		Short: "Root command of the atlas cli plugin example",
-	}
+func Builder() *cobra.Command {
+	return &cobra.Command{
+		Use:   "stdinreader",
+		Short: "Reads name and prints it",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			reader := bufio.NewReader(os.Stdin)
 
-	rootCmd.AddCommand(
-		hello.Builder(),
-		echo.Builder(),
-		printenv.Builder(),
-		stdinreader.Builder(),
-	)
+			fmt.Print("Please enter your name: ")
+			name, err := reader.ReadString('\n')
+			if err != nil {
+				return err
+			}
 
-	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+			name = strings.TrimSpace(name)
+			fmt.Printf("Hello, %s!\n", name)
+			return nil
+		},
 	}
 }


### PR DESCRIPTION
- Add command `printenv` to print all environment variables
- Add command `stdinreader` to read in a name using stdin and print it