### PR TITLE
Disable flag parsing on echo command

### DIFF
--- a/internal/cli/echo/echo.go
+++ b/internal/cli/echo/echo.go
@@ -23,8 +23,9 @@ import (
 
 func Builder() *cobra.Command {
 	return &cobra.Command{
-		Use:   "echo",
-		Short: "Echos the input args",
+		Use:                "echo",
+		Short:              "Echos the input args",
+		DisableFlagParsing: true,
 		RunE: func(_ *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				return errors.New("no args given")


### PR DESCRIPTION
While testing, I noticed that if we run a command like the one below, cobra will try to handle the `--test` flag; we don't want this here since we want to print all arguments as is.
```sh
 ./bin/binary example echo test --test=true
```