### PR TITLE
CLOUDP-287423: [Atlas CLI] Improve example plugin to work on Windows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,8 +24,9 @@ jobs:
     
       - name: Add version to manifest file
         run: |
-          # Change $VERSION in the manifest.yml to the version of the release
-          envsubst < manifest.template.yml > manifest_temp.yml && mv manifest_temp.yml manifest.yml
+          # Convert the manifest template to the final manifest file
+          # This will set the version, github repository owner and name and binary name
+          make generate-all-manifests
 
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -11,5 +11,5 @@ builds:
 
 archives:
   - files:
-      - src: "./manifest.yml"
+      - src: "./manifest{{ if eq .Os \"windows\" }}.windows{{end}}.yml"
         dst: ./manifest.yml

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,29 @@
 
 CLI_SOURCE_FILES?=./cmd/plugin
-CLI_BINARY_NAME=binary
+CLI_BINARY_NAME?=binary
 CLI_DESTINATION=./bin/$(CLI_BINARY_NAME)
+MANIFEST_FILE?=manifest.yml
+WIN_MANIFEST_FILE?=manifest.windows.yml
 
 .PHONY: build
 build: ## Generate the binary in ./bin
 	@echo "==> Building $(CLI_BINARY_NAME) binary"
 	go build -o $(CLI_DESTINATION) $(CLI_SOURCE_FILES)
+
+.PHONY: generate-all-manifests
+generate-all-manifests: generate-manifest generate-manifest-windows
+
+.PHONY: generate-manifest
+generate-manifest: ## Generate the manifest file for non-windows OSes
+	@echo "==> Generating non-windows manifest file"
+	printenv
+	BINARY=$(CLI_BINARY_NAME) envsubst < manifest.template.yml > $(MANIFEST_FILE)
+
+.PHONY: generate-manifest-windows
+generate-manifest-windows: ## Generate the manifest file for windows OSes
+	@echo "==> Generating windows manifest file"
+	printenv
+	CLI_BINARY_NAME="${CLI_BINARY_NAME}.exe" MANIFEST_FILE="$(WIN_MANIFEST_FILE)" $(MAKE) generate-manifest
 
 .PHONY: help
 .DEFAULT_GOAL := help

--- a/manifest.template.yml
+++ b/manifest.template.yml
@@ -4,7 +4,7 @@ version: $VERSION
 github:
     owner: $GITHUB_REPOSITORY_OWNER
     name: $GITHUB_REPOSITORY_NAME
-binary: binary
+binary: $BINARY
 commands: 
     example: 
         description: Root command of the atlas cli plugin example


### PR DESCRIPTION
# Description
## Issue:

Go releaser generates `binary.exe` on windows, but the template contained `binary`
This caused plugins to not work on windows.

## Fix
- Make `BINARY` configurable in the template.
- Add new make targets: `generate-all-manifests`, `generate-manifest`, `generate-manifest-windows`
- Switch which file is included in the archive based on `.Os`

Note that this could have also been resolved with the templating feature in Goreleaser. But I did not use it since it's a pro feature.

Tested on my private fork: https://github.com/jeroenvervaeke/atlas-cli-plugin-example/releases/tag/v0.0.1