### PR TITLE
Added aliases to example repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ binary: binary
 commands: 
     example: 
         description: Root command of the atlas cli plugin example
+        aliases:
+            - example-alias-1
+            - example-alias-2
 ```
 
 | Field | Description | Optional |
@@ -47,6 +50,7 @@ commands:
 | `binary`| The name of the plugin's binary file | No
 | `commands.<command_name>` | An object where the key is the command name and the value is a description of the command | No (a plugin needs at least one command)
 | `commands.<command_name>.description` | A description of the command | No
+| `commands.<command_name>.aliases` | An optional list of aliases for your command, for example a shorthand or a synonym | Yes
 
 > **Important:** 
 > - The `version` field in the manifest file is crucial for the Atlas CLI to identify the installed plugin version and manage updates. Ensure that this field is always aligned with the plugin's release version to enable correct updates.

--- a/cmd/plugin/main.go
+++ b/cmd/plugin/main.go
@@ -29,8 +29,9 @@ import (
 
 func main() {
 	exampleCmd := &cobra.Command{
-		Use:   "example",
-		Short: "Root command of the atlas cli plugin example",
+		Use:     "example",
+		Short:   "Root command of the atlas cli plugin example",
+		Aliases: []string{"example-alias-1", "example-alias-2"},
 	}
 
 	exampleCmd.AddCommand(
@@ -42,16 +43,16 @@ func main() {
 	)
 
 	completionOption := &cobra.CompletionOptions{
-		DisableDefaultCmd: true,
-		DisableNoDescFlag: true,
+		DisableDefaultCmd:   true,
+		DisableNoDescFlag:   true,
 		DisableDescriptions: true,
-		HiddenDefaultCmd: true,
+		HiddenDefaultCmd:    true,
 	}
 	rootCmd := &cobra.Command{
 		DisableFlagParsing: true,
-		DisableAutoGenTag: true,
+		DisableAutoGenTag:  true,
 		DisableSuggestions: true,
-		CompletionOptions: *completionOption,
+		CompletionOptions:  *completionOption,
 	}
 	rootCmd.AddCommand(exampleCmd)
 

--- a/manifest.template.yml
+++ b/manifest.template.yml
@@ -8,3 +8,6 @@ binary: $BINARY
 commands: 
     example: 
         description: Root command of the atlas cli plugin example
+        aliases:
+            - example-alias-1
+            - example-alias-2


### PR DESCRIPTION
Added an example of how to use the new alias support for plugins.

This feature was added in https://github.com/mongodb/mongodb-atlas-cli/commit/227e07a5e4d6fb83cca28b738023e6ee5aefe7c3 and will be included in the next release of the atlas cli.